### PR TITLE
Link to contact form on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,8 +91,7 @@
             This unique commute inspires our approach: start at Mile Zero, immerse yourself in the challenge, and charge ahead.
         </p>
         <h2>Contact Us</h2>
-        <p>If you are interested in our services, please reach out for a free consultation and quote.</p>
-        <p>Email: <a href="mailto:inquiries@milezeroenterprises.com">inquiries@milezeroenterprises.com</a></p>
+        <p>If you are interested in our services, please reach out using our <a href="public/contact/">contact form</a> for a free consultation and quote.</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- direct visitors to the new contact form instead of listing an email address on the homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896583005948327889ceb33aabc5a3c