### PR TITLE
Clarify subscription trial and renewal terms

### DIFF
--- a/wifehacker/docs/wifehacker-tos.html
+++ b/wifehacker/docs/wifehacker-tos.html
@@ -67,8 +67,12 @@
     <section>
       <h2>Subscriptions and Payments</h2>
       <ul>
-        <li>Some features require a paid subscription billed through Google Play.</li>
-        <li>Billing, renewals, and cancellations are managed via your Google Play account settings.</li>
+        <li>Some features require a paid subscription.</li>
+        <li>After creating an account, you receive a 14-day free trial of premium features.</li>
+        <li>When the trial ends, your subscription will automatically renew monthly or annually based on the plan you selected during onboarding.</li>
+        <li>The App uses Google Play Billing to manage purchases, renewals, and cancellations.</li>
+        <li>You may cancel your subscription at any time through your Google Play account settings.</li>
+        <li>If you cancel, you will not be billed on the next renewal date and will retain access to premium features until that date.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- explain 14-day free trial and automatic monthly/annual renewals
- note that Google Play Billing manages subscriptions and cancellations

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976c317c2c832789be9d3dd7decca8