### PR TITLE
Fix privacy links and remove exposed emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ pushed to the default branch are automatically published via GitHub Pages.
 
 ## Contact
 
-For questions about Mile Zero Enterprises or to request deletion of an app account, use our [contact form](public/contact/).
+For questions about Mile Zero Enterprises or to request deletion of an app account, use our [contact form](/public/contact/index.html).
 The form is powered by a serverless backend and handles general inquiries as well as account deletion requests.
 

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             This unique commute inspires our approach: start at Mile Zero, immerse yourself in the challenge, and charge ahead.
         </p>
         <h2>Contact Us</h2>
-        <p>If you are interested in our services, please reach out using our <a href="public/contact/">contact form</a> for a free consultation and quote.</p>
+        <p>If you are interested in our services, please reach out using our <a href="/public/contact/index.html">contact form</a> for a free consultation and quote.</p>
     </div>
 </body>
 </html>

--- a/public/contact/index.html
+++ b/public/contact/index.html
@@ -79,7 +79,7 @@
   </script>
 
   <p style="margin-top:16px;color:#555;font-size:.9rem">
-    For account deletion: we’ll send a confirmation to verify ownership before deletion. See our <a href="/privacy">Privacy Policy</a>.
+    For account deletion: we’ll send a confirmation to verify ownership before deletion. See our <a href="/wifehacker/docs/wifehacker-privacy.html">Privacy Policy</a>.
   </p>
 </body>
 </html>

--- a/wifehacker/docs/wifehacker-privacy.html
+++ b/wifehacker/docs/wifehacker-privacy.html
@@ -31,7 +31,7 @@
       <h2>Who we are</h2>
       <p>Wife Hacker is a relationship support app operated by Mile Zero Enterprises, LLC (“<strong>we</strong>”, “<strong>us</strong>”, “<strong>our</strong>”).
       This Privacy Policy explains how we collect, use, disclose, and protect information when you use the Wife Hacker app and our website located at <code>www.milezeroenterprises.com</code>.</p>
-      <p>Contact: <a href="mailto:milezeroenterprises@gmail.com">milezeroenterprises@gmail.com</a> or use our <a href="/contact/">Contact form</a>.</p>
+        <p>Contact: Use our <a href="/public/contact/index.html">Contact form</a>.</p>
     </section>
 
     <section>
@@ -108,7 +108,7 @@
       <ul>
         <li><strong>Access & Update</strong>: view and update your profile and settings in the app.</li>
         <li><strong>Account Deletion (in‑app)</strong>: from the app’s profile/settings screen, choose “Delete Account” to permanently delete your account and associated data.</li>
-        <li><strong>Account Deletion (outside the app)</strong>: submit a request via our <a href="/contact/">Contact form</a> or visit our <a href="/account-deletion/">Account Deletion page</a>. We’ll verify ownership via your email, then process deletion.</li>
+          <li><strong>Account Deletion (outside the app)</strong>: submit a request via our <a href="/public/contact/index.html">Contact form</a>. We’ll verify ownership via your email, then process deletion.</li>
         <li><strong>Communications</strong>: opt out of non‑essential communications; we may still send transactional or legal notices.</li>
       </ul>
     </section>
@@ -134,7 +134,7 @@
         <li><strong>EEA/UK</strong>: Where applicable, our legal bases include performance of a contract (providing the service), legitimate interests (security, analytics), and consent (where requested). You may have rights to access, rectify, erase, or restrict processing of your data and to object to processing or request portability.</li>
         <li><strong>California</strong>: We do not sell or share personal information as defined by the CCPA/CPRA. You may request deletion and access to categories of personal information we collect, and you have the right to not be discriminated against for exercising these rights.</li>
       </ul>
-      <p>To exercise any rights, contact us via <a href="/contact/">/contact/</a> or email <a href="mailto:milezeroenterprises@gmail.com">milezeroenterprises@gmail.com</a>.</p>
+        <p>To exercise any rights, contact us via our <a href="/public/contact/index.html">Contact form</a>.</p>
     </section>
 
     <section>
@@ -149,13 +149,13 @@
 
     <section>
       <h2>Contact us</h2>
-      <p>If you have questions, concerns, or requests related to privacy or data protection, contact us at <a href="mailto:milezeroenterprises@gmail.com">milezeroenterprises@gmail.com</a> or submit via our <a href="/contact/">Contact form</a>.</p>
+        <p>If you have questions, concerns, or requests related to privacy or data protection, submit them through our <a href="/public/contact/index.html">Contact form</a>.</p>
     </section>
 
     <section>
       <h2>Google Play account deletion disclosure</h2>
       <p>In accordance with Google Play policies, Wife Hacker provides a readily discoverable account deletion option both <strong>inside the app</strong> and <strong>outside the app</strong> on the web. When you delete your account, we permanently delete personal data associated with that account as described above. If limited data must be retained for security, fraud prevention, or legal reasons, we disclose those categories in this Policy and restrict retention to the minimum period necessary.</p>
-      <p>Outside‑the‑app deletion path: <a href="/contact/">/contact/</a>.</p>
+        <p>Outside‑the‑app deletion path: <a href="/public/contact/index.html">Contact form</a>.</p>
     </section>
 
     <p class="small">Mile Zero Enterprises, LLC • New Orleans, LA • USA</p>

--- a/wifehacker/docs/wifehacker-tos.html
+++ b/wifehacker/docs/wifehacker-tos.html
@@ -78,7 +78,7 @@
 
     <section>
       <h2>Account Deletion</h2>
-      <p>You may delete your account at any time using the in-app “Delete Account” option or by submitting a request via our <a href="/contact/">Contact form</a> or <a href="/account-deletion/">Account Deletion page</a>. Upon verification, we will permanently delete your personal data, except as required for security, fraud prevention, or legal compliance, as outlined in our <a href="/wifehacker/docs/privacy-policy.html">Privacy Policy</a>.</p>
+        <p>You may delete your account at any time using the in-app “Delete Account” option or by submitting a request via our <a href="/public/contact/index.html">Contact form</a>. Upon verification, we will permanently delete your personal data, except as required for security, fraud prevention, or legal compliance, as outlined in our <a href="/wifehacker/docs/wifehacker-privacy.html">Privacy Policy</a>.</p>
     </section>
 
     <section>
@@ -118,7 +118,7 @@
 
     <section>
       <h2>Contact Us</h2>
-      <p>For questions about these Terms, contact us at <a href="mailto:milezeroenterprises@gmail.com">milezeroenterprises@gmail.com</a> or via our <a href="/contact/">Contact form</a>.</p>
+        <p>For questions about these Terms, reach us through our <a href="/public/contact/index.html">Contact form</a>.</p>
     </section>
 
     <p class="small">Mile Zero Enterprises, LLC • New Orleans, LA • USA</p>


### PR DESCRIPTION
## Summary
- Point all site contact links to `/public/contact/index.html`
- Remove plain text email addresses from policy and terms pages
- Remove references to nonexistent `/account-deletion` page
- Ensure all privacy policy links route to `/wifehacker/docs/wifehacker-privacy.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba2c7b05c83279571590ec2128013