### PR TITLE
Add app-ads.txt entry for Google AdMob

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2165263113649351, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- add an app-ads.txt file at the site root containing the Google AdMob publisher entry per IAB Tech Lab requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daca56631483279d4b579deca8b8fd