### PR TITLE
Raise live chat timeout to ride out Anthropic 529 retries

### DIFF
--- a/celebration-demo/adriana.html
+++ b/celebration-demo/adriana.html
@@ -123,7 +123,9 @@
     window.CELEBRATION_CONFIG = {
       USE_MOCK: false,
       WEBHOOK_URL: 'https://milezeroenterprises.app.n8n.cloud/webhook/celebration-demo',
-      LIVE_TIMEOUT_MS: 9000
+      // Allow time for the n8n Anthropic node to retry transient 529 "Overloaded"
+      // errors (maxTries 3, ~2s backoff) before the client aborts to the fallback.
+      LIVE_TIMEOUT_MS: 20000
     };
   </script>
   <script src="assets/app.js"></script>


### PR DESCRIPTION
Live Adriana chat showed the backend "trouble connecting" apology when the Anthropic API returned a transient 529 "Overloaded" (confirmed in the n8n execution log). The n8n Anthropic node now retries overloaded calls (maxTries 3, ~2s backoff), but those retries can exceed the old 9s client timeout, causing the browser to abort to the weak scripted fallback before the retry succeeds.

Raise LIVE_TIMEOUT_MS 9000 -> 20000 so the client waits for the retried call to return a real, grounded answer. Pairs with the n8n node retry settings (already published).